### PR TITLE
Handle the case when params are None.

### DIFF
--- a/bq_dts/base_connector.py
+++ b/bq_dts/base_connector.py
@@ -254,6 +254,7 @@ def templatize_table_name(table_template, run_ctx: ManagedTransferRun):
     run_time = run_ctx.transfer_run['run_time']
 
     table_params = copy.deepcopy(run_ctx.transfer_run['params'])
+    table_params = table_params or dict()
 
     table_params['run_time'] = run_time
     table_params['run_yyyymmmdd'] = f'{run_time:%Y%m%d}'
@@ -358,6 +359,9 @@ class BaseConnector(object):
 
         # Step 3 - Data Source Definintion parsing
         data_source_dict = self._connector_config['data_source_definition']['data_source']
+        # If there are no parameters create one to avoid a null check.
+        data_source_dict['parameters'] = data_source_dict['parameters'] or dict()
+
         self._required_params_set = {
             current_param['param_id'] for current_param in data_source_dict['parameters'] if current_param.get('required')
         }

--- a/bq_dts/helpers.py
+++ b/bq_dts/helpers.py
@@ -162,6 +162,8 @@ def normalize_transfer_run(transfer_run, integer_params=None):
     #   param_name: {string_value: '1901-01-01'}
     # TO
     #   param_name: '1901-01-01'
+    if not 'params' in transfer_run or not out_transfer_run['params']:
+        out_transfer_run['params'] = None
     out_params = protobuf_struct_to_python_dict(out_transfer_run['params'])
 
     # Step 2 - For BQ DTS specifically, cast explicit params to integers
@@ -179,6 +181,9 @@ def normalize_transfer_run(transfer_run, integer_params=None):
 
 def protobuf_struct_to_python_dict(raw_struct):
     # https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#struct
+    if raw_struct is None:
+        return raw_struct
+
     output_dict = dict()
     for var_name, var_value in raw_struct['fields'].items():
         output_dict[var_name] = _struct_value_to_python_value(var_value)


### PR DESCRIPTION
The base_connector logic assumes that a connector will always have parameters. 

Added several checks to handle this scenario.