### PR TITLE
Create a setup.py file to allow distribution support.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,8 @@
+from distutils.core import setup
+
+setup(name='bq-dts-partner-sdk',
+      version='0.0',
+      description='BigQuery Data Transfer Service - Integration SDK',
+      url='https://github.com/mtai/bq-dts-partner-sdk/',
+      packages=['bq_dts'],
+      )


### PR DESCRIPTION
Added to allow the bq-dts-partner-sdk to be downloaded directly from github in a connector requirements.txt file.