### PR TITLE
Fix case where no params are defined for a transfer run

### DIFF
--- a/bq_dts/helpers.py
+++ b/bq_dts/helpers.py
@@ -182,7 +182,7 @@ def normalize_transfer_run(transfer_run, integer_params=None):
 def protobuf_struct_to_python_dict(raw_struct):
     # https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#struct
     if raw_struct is None:
-        return raw_struct
+        return dict()
 
     output_dict = dict()
     for var_name, var_value in raw_struct['fields'].items():


### PR DESCRIPTION
When no params are defined for a transfer run, the `out_params` in ` normalize_transfer_run()` get defined as `None` which in turn breaks validation in `BaseConnector.validate_transfer_run_params()`.